### PR TITLE
paper_trail 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ elsif ENV['RAILS'] == "4.1"
   gem 'globalize', '~> 4.0'
 else # Rails 4.2
   gem 'globalize', '~> 5.0'
-  gem 'paper_trail', '4.0.0.beta2'
+  gem 'paper_trail', '~> 6.0'
 end

--- a/globalize-versioning.gemspec
+++ b/globalize-versioning.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemodel', '>= 3.2.0', '< 5'
   s.add_dependency 'globalize', '>= 3.0.4', '< 6'
 
-  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 5'
+  s.add_dependency 'paper_trail',  '>= 3.0.0', '<= 6'
 
   s.add_development_dependency 'database_cleaner', '>= 1.2.0'
   s.add_development_dependency 'minitest'

--- a/lib/globalize/versioning/version.rb
+++ b/lib/globalize/versioning/version.rb
@@ -1,5 +1,5 @@
 module Globalize
   module Versioning
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
Pri pokusoch s `globalize_versioning` sa ukazali urcite nekompatibility verzii, preto ze ten gem nebol dlhsi cas upgradovany a konfliktovalo to s `paper_trail` (instalovalo verziu 4.2.0 a `rails_admin`.
Skusil som povolit dependency na `paper_trail` az po verziu 6 a zda sa ze to funguje.
Budeme teda pouzivat tento fork miesto verzie ktora je v rubygems.